### PR TITLE
Add support to show multiple supervisor processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 - connect to http with login and password
+- Show the list of all supervisor processes that failed 
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- connect to http with login and password
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- Show the list of all supervisor processes that failed 
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -30,37 +30,37 @@ require 'ruby-supervisor'
 class CheckSupervisor < Sensu::Plugin::Check::CLI
   option :host,
          description: 'Hostname to check',
-         short: '-H HOST',
-         long: '--host HOST',
-         default: 'localhost'
+         short:       '-H HOST',
+         long:        '--host HOST',
+         default:     'localhost'
 
   option :port,
          description: 'Supervisor port',
-         short: '-p PORT',
-         long: '--port PORT',
-         default: 9001
+         short:       '-p PORT',
+         long:        '--port PORT',
+         default:     9001
 
   option :username,
-         description:   'Supervisor HTTP username',
-         short:         '-u USERNAME',
-         long:          '--username USERNAME'
+         description: 'Supervisor HTTP username',
+         short:       '-u USERNAME',
+         long:        '--username USERNAME'
 
   option :password,
-         description:   'Supervisor HTTP password',
-         short:         '-p PASSWORD',
-         long:          '--password PASSWORD'
+         description: 'Supervisor HTTP password',
+         short:       '-p PASSWORD',
+         long:        '--password PASSWORD'
 
   option :critical,
          description: 'Supervisor states to consider critical',
-         short: '-c STATE[,STATE...]',
-         long: '--critical STATE[,STATE...]',
-         proc: proc { |v| v.upcase.split(',') },
-         default: ['FATAL']
+         short:       '-c STATE[,STATE...]',
+         long:        '--critical STATE[,STATE...]',
+         proc:        proc { |v| v.upcase.split(',') },
+         default:     ['FATAL']
 
   option :help,
          description: 'Show this message',
-         short: '-h',
-         long: '--help'
+         short:       '-h',
+         long:        '--help'
 
   def run
     if config[:help]

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -70,7 +70,7 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
       failed_processes << "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
     end
 
-    critical "\n#{failed_processes.to_a.join("\n")}" if not failed_processes.empty?
+    critical "\n#{failed_processes.to_a.join("\n")}" unless failed_processes.empty?
 
     ok 'All processes running'
   end # def run

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -26,6 +26,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'ruby-supervisor'
+require 'set'
 
 class CheckSupervisor < Sensu::Plugin::Check::CLI
   option :host,
@@ -84,9 +85,12 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
       critical "Tried to access #{config[:host]} but failed"
     end
 
+    failed_processes = Set.new
     @super.processes.each do |process|
-      critical "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
+      failed_processes << "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
     end
+
+    critical "\n#{failed_processes.to_a.join("\n")}" if not failed_processes.empty?
 
     ok 'All processes running'
   end # def run

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -40,6 +40,16 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
          long: '--port PORT',
          default: 9001
 
+  option :username,
+         description:   'Supervisor HTTP username',
+         short:         '-u USERNAME',
+         long:          '--username USERNAME'
+
+  option :password,
+         description:   'Supervisor HTTP password',
+         short:         '-p PASSWORD',
+         long:          '--password PASSWORD'
+
   option :critical,
          description: 'Supervisor states to consider critical',
          short: '-c STATE[,STATE...]',
@@ -58,8 +68,18 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
       exit
     end
 
+    params = {}
+
+    if config[:username]
+      params[:username] = config[:username]
+    end
+
+    if config[:password]
+      params[:password] = config[:password]
+    end
+
     begin
-      @super = RubySupervisor::Client.new(config[:host], config[:port])
+      @super = RubySupervisor::Client.new(config[:host], config[:port], params)
     rescue
       critical "Tried to access #{config[:host]} but failed"
     end

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -26,6 +26,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'ruby-supervisor'
+require 'set'
 
 class CheckSupervisor < Sensu::Plugin::Check::CLI
   option :host,
@@ -64,9 +65,12 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
       critical "Tried to access #{config[:host]} but failed"
     end
 
+    failed_processes = Set.new
     @super.processes.each do |process|
-      critical "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
+      failed_processes << "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
     end
+
+    critical "\n#{failed_processes.to_a.join("\n")}" if not failed_processes.empty?
 
     ok 'All processes running'
   end # def run

--- a/bin/check-supervisor.rb
+++ b/bin/check-supervisor.rb
@@ -90,7 +90,7 @@ class CheckSupervisor < Sensu::Plugin::Check::CLI
       failed_processes << "#{process['name']} not running: #{process['statename'].downcase}" if config[:critical].include?(process['statename'])
     end
 
-    critical "\n#{failed_processes.to_a.join("\n")}" if not failed_processes.empty?
+    critical "\n#{failed_processes.to_a.join("\n")}" unless failed_processes.empty?
 
     ok 'All processes running'
   end # def run


### PR DESCRIPTION
Show all the processes that failed as part of supervisor instead of stopping at the first one
