### PR TITLE
Update check-supervisor-socket.rb to use XMLRPC::XMLParser::LibXMLStreamParser 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-supervisor-socket.rb: update XMLRPC::XMLParser::XMLStreamParser to XMLRPC::XMLParser::LibXMLStreamParser as per issue https://github.com/sensu-plugins/sensu-plugins-supervisor/issues/16
 
 ## [1.0.0] - 2016-11-07
 ### Added

--- a/bin/check-supervisor-socket.rb
+++ b/bin/check-supervisor-socket.rb
@@ -90,7 +90,7 @@ class CheckSupervisorSocket < Sensu::Plugin::Check::CLI
       response.reading_body(@super, request.response_body_permitted?) {}
       @super.close
 
-      success, result = XMLRPC::XMLParser::XMLStreamParser.new.parseMethodResponse(response.body)
+      success, result = XMLRPC::XMLParser::LibXMLStreamParser.new.parseMethodResponse(response.body)
       raise unless success
     rescue => e
       critical "Tried requesting XMLRPC 'supervisor.getAllProcessInfo' from UNIX domain socket #{config[:socket]} but failed: #{e}"


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** [ISSUE-16](https://github.com/sensu-plugins/sensu-plugins-supervisor/issues/16)

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Upgrading Sensu to 0.29 will upgraded the embedded ruby to version 2.4.0.

This causes the following error to occur:
```
CheckSupervisorSocket CRITICAL: Tried requesting XMLRPC 'supervisor.getAllProcessInfo' from UNIX domain socket /var/run/supervisor.sock but failed: uninitialized constant XMLRPC::XMLParser::XMLStreamParser
Did you mean? XMLRPC::XMLParser::LibXMLStreamParser
```
This Pull Requests updates XMLRPC::XMLParser::XMLStreamParser to XMLRPC::XMLParser::LibXMLStreamParser.

Tagging @eheydrick for review.

#### Known Compatablity Issues
This update may impact users who have not yet upgraded to Sensu 0.29.