### PR TITLE
Switch to ox XMLRPC parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-supervisor-socket.rb: Switched to ox for xmlrpc parser, fixes #19.
 
 ## [1.0.2] 2017-06-01
 - sensu-plugins-supervisor.gemspec: update Gemspec and README as per issue https://github.com/sensu-plugins/sensu-plugins-supervisor/issues/15

--- a/README.md
+++ b/README.md
@@ -16,18 +16,6 @@
 
 ## Installation
 
-You will need the `expat` development library installed prior to installing this plugin. For CentOS/RHEL systems:
-
-```
-yum install expat-devel
-```
-
-Ubuntu systems:
-
-```
-apt-get install libexpat1-dev
-```
-
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes

--- a/bin/check-supervisor-socket.rb
+++ b/bin/check-supervisor-socket.rb
@@ -15,7 +15,7 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: libxml-xmlrpc
+#   gem: ox
 #
 # USAGE:
 #   check-supervisor-socket.rb
@@ -31,6 +31,7 @@ require 'net/http'
 require 'socket'
 require 'xmlrpc/create'
 require 'xmlrpc/parser'
+require 'ox/xmlrpc_adapter'
 
 class CheckSupervisorSocket < Sensu::Plugin::Check::CLI
   option :socket,
@@ -90,7 +91,7 @@ class CheckSupervisorSocket < Sensu::Plugin::Check::CLI
       response.reading_body(@super, request.response_body_permitted?) {}
       @super.close
 
-      success, result = XMLRPC::XMLParser::LibXMLStreamParser.new.parseMethodResponse(response.body)
+      success, result = Ox::StreamParser.new.parseMethodResponse(response.body)
       raise unless success
     rescue => e
       critical "Tried requesting XMLRPC 'supervisor.getAllProcessInfo' from UNIX domain socket #{config[:socket]} but failed: #{e}"

--- a/sensu-plugins-supervisor.gemspec
+++ b/sensu-plugins-supervisor.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSupervisor::Version::VER_STRING
 
+  s.add_runtime_dependency 'ox', '~> 2.5.0'
   s.add_runtime_dependency 'ruby-supervisor', '0.0.2'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'xmlparser', '~> 0.7.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** Yes - #19.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Ruby 2.4 dropped the expat parser in favour of libxml (see #16 and #17, and [this](https://fossies.org/diffs/ruby/2.3.3_vs_2.4.0/lib/xmlrpc.rb-diff.html)).

I've switched the parser to use [ox](https://github.com/ohler55/ox), which is self-contained and relies on standard C libraries. It's also much faster than rexml (the other option, which is a native Ruby implementation).

#### Known Compatibility Issues
There's a separate issue affecting 2.4, see #20