### PR TITLE
fixes #20 by conditionally installing xmlrpc at install time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -28,4 +29,5 @@ deploy:
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-supervisor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- support for ruby 2.4: issues caused by `libxmlrpc` being removed from ruby 2.4. Basically we need to solve this by checking the version of ruby at **install time** where dependencies in `.gemspec` are specified at **build time**. This requires using a ruby extension. I included comments in several places to make this more obvious to users that might be confused by this behavior. I also included some Dockerfiles for ruby 2.2-2.4 so that we can test this out better.
+
 ## [1.0.3] 2017-06-07
 ### Fixed
 - check-supervisor-socket.rb: Switched to ox for xmlrpc parser, fixes #19.

--- a/Dockerfile-ruby2.2
+++ b/Dockerfile-ruby2.2
@@ -1,0 +1,12 @@
+FROM ruby:2.2-slim
+
+# some basic stuff
+RUN mkdir /usr/src/app
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+# install required packages
+RUN apt-get update \
+  && apt-get install -y build-essential
+
+CMD ["./docker-test"]

--- a/Dockerfile-ruby2.3
+++ b/Dockerfile-ruby2.3
@@ -1,0 +1,12 @@
+FROM ruby:2.3-slim
+
+# some basic stuff
+RUN mkdir /usr/src/app
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+# install required packages
+RUN apt-get update \
+  && apt-get install -y build-essential
+
+CMD ["./docker-test"]

--- a/Dockerfile-ruby2.4
+++ b/Dockerfile-ruby2.4
@@ -1,0 +1,12 @@
+FROM ruby:2.4-slim
+
+# some basic stuff
+RUN mkdir /usr/src/app
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+# install required packages
+RUN apt-get update \
+  && apt-get install -y build-essential
+
+CMD ["./docker-test"]

--- a/README.md
+++ b/README.md
@@ -18,4 +18,179 @@
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
+### Some extra info on a hack regarding xmlrpc
+So in ruby 2.4 they removed `xmlrpc` from stdlib and made it a ruby gem. As this gem is only installable on 2.3 (according to doc but most users report being unable to install in 2.3) this creates problems. On the surface you might think that we could do something like this in the `.gemspec`:
+
+```ruby
+if RUBY_VERSION >= "2.4"
+  installer.install "xmlrpc", "~> 0.3"
+end
+```
+
+However this is not something we need evaluated at build time but actually at install time. Ruby does not have a great way of doing this but we can accomplish this by using a c extension to force this behavior at run time. This was based off: http://www.programmersparadox.com/2012/05/21/gemspec-loading-dependent-gems-based-on-the-users-system/
+
+### Testing this behavior
+I have included 2 dockerfiles to test installing on ruby 2.3 and ruby 2.4.
+
+#### Building
+Ruby 2.2:
+```
+$ docker build -f Dockerfile-ruby2.2 .
+Sending build context to Docker daemon  221.2kB
+Step 1/6 : FROM ruby:2.2-slim
+2.2-slim: Pulling from library/ruby
+10a267c67f42: Already exists
+0aaa89427703: Already exists
+4e4351445696: Already exists
+72c399ee88ad: Pull complete
+cd4fc9895ed7: Pull complete
+00facae99acf: Pull complete
+Digest: sha256:9f39e5306ac98b6ff46a7f5247ace88b4e3723a3fe04dcfa317cabed07dadd8f
+Status: Downloaded newer image for ruby:2.2-slim
+ ---> 81e5c2fd16a9
+Step 2/6 : RUN mkdir /usr/src/app
+ ---> Running in f92de1d4ae5a
+ ---> 7e0786e64a4a
+Removing intermediate container f92de1d4ae5a
+Step 3/6 : ADD . /usr/src/app
+ ---> 9d2cb5c24d80
+Removing intermediate container e52c9e26d2cc
+Step 4/6 : WORKDIR /usr/src/app
+ ---> 94d1e262851f
+Removing intermediate container 427d79912bd9
+Step 5/6 : RUN apt-get update   && apt-get install -y build-essential
+ ---> Running in 62819ad68ade
+<INTENTIONALLY_REMOVED_OUTPUT_FROM_APT>
+ ---> 4ee671ec2163
+Removing intermediate container 62819ad68ade
+Step 6/6 : CMD ./docker-test
+ ---> Running in 25d0d0e45692
+ ---> d0339d43c554
+Removing intermediate container 25d0d0e45692
+Successfully built d0339d43c554
+```
+
+Ruby 2.3:
+```
+$ docker build -f Dockerfile-ruby2.3 .
+Sending build context to Docker daemon  179.7kB
+Step 1/6 : FROM ruby:2.3-slim
+ ---> 684863def0d3
+Step 2/6 : RUN mkdir /usr/src/app
+ ---> Using cache
+ ---> e62979ea3e34
+Step 3/6 : ADD . /usr/src/app
+ ---> 7bbdf2f16ff5
+Removing intermediate container bdaf432e06fe
+Step 4/6 : WORKDIR /usr/src/app
+ ---> b9b014ac62a2
+Removing intermediate container 0f9ebd7711ff
+Step 5/6 : RUN apt-get update   && apt-get install -y build-essential
+ ---> Running in 06d6ce00c56d
+<INTENTIONALLY_REMOVED_OUTPUT_FROM_APT>
+ ---> 30e212e3dc48
+Removing intermediate container 06d6ce00c56d
+Step 6/6 : CMD ./docker-test
+ ---> Running in a1205ff9acce
+ ---> e9e3c5affbc0
+Removing intermediate container a1205ff9acce
+Successfully built e9e3c5affbc0
+```
+
+Ruby 2.4:
+```
+$ docker build -f Dockerfile-ruby2.4 .
+Sending build context to Docker daemon  178.2kB
+Step 1/6 : FROM ruby:2.4-slim
+ ---> 6dd077757d49
+Step 2/6 : RUN mkdir /usr/src/app
+ ---> Using cache
+ ---> 4f45395487f3
+Step 3/6 : ADD . /usr/src/app
+ ---> fd2af990b369
+Removing intermediate container 6b5e7cc4a515
+Step 4/6 : WORKDIR /usr/src/app
+ ---> f2019fc2ae01
+Removing intermediate container d471aea79711
+Step 5/6 : RUN apt-get update   && apt-get install -y build-essential
+ ---> Running in 3f9106d17a3d
+<INTENTIONALLY_REMOVED_OUTPUT_FROM_APT>
+ ---> ae1a635f5731
+Removing intermediate container 3f9106d17a3d
+Step 6/6 : CMD ./docker-test
+ ---> Running in ccc8b4be1d08
+ ---> 6d927a3f6fd1
+Removing intermediate container ccc8b4be1d08
+Successfully built 6d927a3f6fd1
+```
+
+#### Validation
+Ruby 2.2:
+```
+$ docker run d0339d43c554
+WARNING:  pessimistic dependency on ox (~> 2.5.0) may be overly strict
+  if ox is semantically versioned, use:
+    add_runtime_dependency 'ox', '~> 2.5', '>= 2.5.0'
+WARNING:  See http://guides.rubygems.org/specification-reference/ for help
+  Successfully built RubyGem
+  Name: sensu-plugins-supervisor
+  Version: 1.1.0
+  File: sensu-plugins-supervisor-1.1.0.gem
+Successfully installed mixlib-cli-1.7.0
+Successfully installed sensu-plugin-1.4.5
+Successfully installed ruby-supervisor-0.0.2
+Building native extensions.  This could take a while...
+Successfully installed ox-2.5.0
+Building native extensions.  This could take a while...
+You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu
+Successfully installed sensu-plugins-supervisor-1.1.0
+5 gems installed
+```
+
+Ruby 2.3:
+```
+$ docker run e9e3c5affbc0
+WARNING:  pessimistic dependency on ox (~> 2.5.0) may be overly strict
+  if ox is semantically versioned, use:
+    add_runtime_dependency 'ox', '~> 2.5', '>= 2.5.0'
+WARNING:  See http://guides.rubygems.org/specification-reference/ for help
+  Successfully built RubyGem
+  Name: sensu-plugins-supervisor
+  Version: 1.1.0
+  File: sensu-plugins-supervisor-1.1.0.gem
+Successfully installed mixlib-cli-1.7.0
+Successfully installed sensu-plugin-1.4.5
+Successfully installed ruby-supervisor-0.0.2
+Building native extensions.  This could take a while...
+Successfully installed ox-2.5.0
+Building native extensions.  This could take a while...
+You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu
+Successfully installed sensu-plugins-supervisor-1.1.0
+5 gems installed
+```
+
+Ruby 2.4:
+```
+$ docker run 6d927a3f6fd1
+WARNING:  pessimistic dependency on ox (~> 2.5.0) may be overly strict
+  if ox is semantically versioned, use:
+    add_runtime_dependency 'ox', '~> 2.5', '>= 2.5.0'
+WARNING:  See http://guides.rubygems.org/specification-reference/ for help
+  Successfully built RubyGem
+  Name: sensu-plugins-supervisor
+  Version: 1.1.0
+  File: sensu-plugins-supervisor-1.1.0.gem
+Building native extensions.  This could take a while...
+Successfully installed json-1.8.6
+Successfully installed mixlib-cli-1.7.0
+Successfully installed sensu-plugin-1.4.5
+Successfully installed ruby-supervisor-0.0.2
+Building native extensions.  This could take a while...
+Successfully installed ox-2.5.0
+Building native extensions.  This could take a while...
+You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu
+Successfully installed sensu-plugins-supervisor-1.1.0
+6 gems installed
+```
+
 ## Notes

--- a/docker-test
+++ b/docker-test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gem build /usr/src/app/sensu-plugins-supervisor.gemspec
+
+gem install sensu-plugins-supervisor-*.gem

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,29 @@
+# This file needs to be named mkrf_conf.rb
+# so that rubygems will recognize it as a ruby extension
+# file and not think it is a C extension file
+
+require 'rubygems/dependency_installer.rb'
+
+# Load up the rubygem's dependency installer to
+# installer the gems we want based on the version
+# of Ruby the user has installed
+
+installer = Gem::DependencyInstaller.new
+
+begin
+  if RUBY_VERSION >= '2.4'
+    installer.install 'xmlrpc', '~> 0.3'
+  end
+
+rescue => e
+  p e
+  # Exit with a non-zero value to let rubygems something went wrong
+  exit(1)
+end
+
+# If this was C, rubygems would attempt to run make
+# Since this is Ruby, rubygems will attempt to run rake
+# If it doesn't find and successfully run a rakefile, it errors out
+f = File.open(File.join(File.dirname(__FILE__), 'Rakefile'), 'w')
+f.write("task :default\n")
+f.close

--- a/lib/sensu-plugins-supervisor/version.rb
+++ b/lib/sensu-plugins-supervisor/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsSupervisor
   module Version
     MAJOR = 1
-    MINOR = 0
-    PATCH = 3
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-supervisor.gemspec
+++ b/sensu-plugins-supervisor.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |s|
                               for monitoring service status'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
+  # ./ext/mkrf_conf.rb is not a normal c extension file, its a hack but a neccessary one
+  # due to xmlrpc only being a gem that can be installed on ruby 2.3 or later and prior
+  # to 2.4 it was part of stdlib
+  s.extensions             = Dir.glob('ext/**/*.rb')
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-supervisor'
   s.license                = 'MIT'
@@ -33,6 +37,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ox', '~> 2.5.0'
   s.add_runtime_dependency 'ruby-supervisor', '0.0.2'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  # when we drop ruby < 2.4 support we can add this and remove
+  # the extension to conditionally deal with breaking changes
+  # across ruby versions and uncomment the following:
+  # s.add_runtime_dependency 'xmlrpc', '~> 0.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
A bit of background:
in ruby version 2.4 they removed xmlrpc from std lib. So we need to conditionally install it depending on what version of ruby is being used on the target system (not the build system).

It seems tempting (and wrong) to say just put this in the `.gemspec` but this is evaluated at **build** time and we want to check this at **install** time.

To my limited knowledge the only way to do this is to create a ruby extension to check and deal with this at install time. I have commented in the `.gemspec` about this so that its less "silent" when someone is looking through it. I have also included several dockerfiles that are meant to be used to test build and install of gem on ruby 2.2, ruby 2.3, and ruby 2.4 and have appropriate information in README on how to use.

## Pull Request Checklist

The saga of issues related:
#15, #16, #17, #18, #19

This is geared towards solving #20 which should close out any further concerns about xmlrpc.
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Conditionally add `xmlrpc` gem as a dep on ruby 2.4 during **install** time vs **build** time.
#### Known Compatibility Issues
None that I am aware of.
